### PR TITLE
Labs review

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@ Explore this set of articles to navigate and implement GenAIOps smoothly. These 
 
 ## Labs & How-to
 
-Below are the step-by-step guides that form the hands-on exercises for the GenAIOps Workshop (and can be used standalone for practical implementation):
+The following step-by-step guides are the hands-on exercises for the GenAIOps Workshop. They are designed to be completed during the workshop but can also be used independently as practical implementation guides.
 
-1. [Bootstrapping a New Project](labs/bootstrapping.md)  
-2. [From Idea to Prototype](labs/prototyping.md)  
-3. [Building Your GenAI App](labs/building.md)  
-4. [Evaluating Your App Responses](labs/evaluating.md)  
-5. [Automating Deployment with CI/CD](labs/automating.md)  
+**Pre-work (Must be completed before the workshop begins):**
+
+* [Bootstrapping a New Project](labs/bootstrapping.md)
+
+**Workshop Labs:**
+
+1. [From Idea to Prototype](labs/prototyping.md)
+2. [Building Your GenAI App](labs/building.md)
+3. [Evaluating Your App Responses](labs/evaluating.md)
+4. [Automating Deployment with CI/CD](labs/automating.md)
 
 ## Contributing
 

--- a/labs/automating.md
+++ b/labs/automating.md
@@ -1,4 +1,4 @@
-# Lab 5: Automating Deployment with CI/CD
+# Lab: Automating Deployment with CI/CD
 
 In this lab, you will configure GitHub Actions for your repo, inspect the two pipeline definitions, and run through the full feature-to-deploy workflow. You’ll learn how to:
 

--- a/labs/bootstrapping.md
+++ b/labs/bootstrapping.md
@@ -98,4 +98,4 @@ Note: To run the deployment automation lab, you need a Service Principal with Co
 
 3. Browse to your orchestrator endpoint URL (displayed by `azd provision`) and confirm it returns a "404 Not Found"—indicating the app is deployed and ready to accept requests.
 
-Congratulations—you've successfully bootstrapped a new GenAI project using the GPT-RAG orchestrator template! You’re now ready to move on to Lab 2: From Idea to Prototype.
+Congratulations—you've successfully bootstrapped a new GenAI project using the GPT-RAG orchestrator template! You’re now ready to move on to Lab: From Idea to Prototype.

--- a/labs/evaluating.md
+++ b/labs/evaluating.md
@@ -1,4 +1,4 @@
-# Lab 4: Evaluating Your App Responses
+# Lab: Evaluating Your App Responses
 
 In this lab, you’ll use the built-in evaluation harness in your orchestrator template to measure how well your agent answers real questions from the Contoso Electronics Employee Handbook. The template includes an `evaluations` folder with a Python script (`evaluate.py`) and a test dataset (`chat_eval_data.jsonl`). You will run that script from PowerShell, inspect the JSON output locally, then review the same results in the Azure AI Studio portal under your AI Foundry project’s **Evaluations** tab.
 

--- a/labs/prototyping.md
+++ b/labs/prototyping.md
@@ -23,7 +23,6 @@ In this lab, you will select and compare AI models in Azure AI Foundry, then pro
 ### Required Tools & Access  
 - **Azure Portal** access with contributor rights on your AI Foundry  
 - **Azure AI Foundry** enabled in your subscription  
-- The Contoso Electronics **Employee Handbook** indexed in Azure Cognitive Services (from Lab 1)  
 - Familiarity with the Azure Portal UI  
 
 </details>
@@ -180,6 +179,6 @@ To index the content, deploy the data ingestion service that chunks and indexes 
 ---
 
 **✅ Congratulations!**
-You’ve completed **Lab 1**: explored models, performed benchmarking, and built a prototype agent using real documentation from Contoso Electronics.
+You’ve completed **From Idea to Prototype Lab**: explored models, performed benchmarking, and built a prototype agent using real documentation from Contoso Electronics.
 
-Up next: **Lab 1**, where you’ll implement GenAI app features in code.
+Up next: **Building Lab**, where you’ll implement GenAI app features in code.


### PR DESCRIPTION
This pull request focuses on improving the structure and clarity of the GenAIOps workshop documentation. The changes include reorganizing the workshop labs in the `README.md` file, standardizing lab titles across all lab files, and refining references to labs for better consistency.

### Documentation structure improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R35): Updated the workshop lab section to separate pre-work from workshop labs, added clearer descriptions, and reorganized the list for better readability.

### Lab title standardization:

* [`labs/automating.md`](diffhunk://#diff-c1dfaa32677b9b56502cd50471b9a627f701297a0e8fdde15a0f1533ebb5c82bL1-R1): Renamed the title from "Lab 5: Automating Deployment with CI/CD" to "Lab: Automating Deployment with CI/CD" for consistency.
* [`labs/evaluating.md`](diffhunk://#diff-3bc57437d5b80757d97a61ac2900e31f2c05162a802af1f098c13c894cfc72a3L1-R1): Renamed the title from "Lab 4: Evaluating Your App Responses" to "Lab: Evaluating Your App Responses" for consistency.

### Lab reference consistency:

* [`labs/bootstrapping.md`](diffhunk://#diff-2e7760a8be924fd0a5444fcfc08328247edca65b1eec7ede99677ecdc2fab27aL101-R101): Updated the reference to the next lab from "Lab 2: From Idea to Prototype" to "Lab: From Idea to Prototype" for consistency.
* [`labs/prototyping.md`](diffhunk://#diff-2aa468be1cad35691e38233999bd56a42de0e99da126b0119b47b7d81709c73eL183-R184): Adjusted the completion message to refer to the next lab as "Building Lab" instead of "Lab 1" for improved clarity and alignment with the updated structure.